### PR TITLE
Fix null Stage lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Tatter\Workflows
 Job action control through dynamic workflows, for CodeIgniter 4
 
-[![](https://github.com/tattersoftware/workflows/workflows/PHPUnit/badge.svg)](https://github.com/tattersoftware/workflows/actions?query=workflow%3A%22PHPUnit%22)
-[![](https://github.com/tattersoftware/workflows/workflows/PHPStan/badge.svg)](https://github.com/tattersoftware/workflows/actions?query=workflow%3A%PHPStan%22)
+[![](https://github.com/tattersoftware/codeigniter4-workflows/workflows/PHPUnit/badge.svg)](https://github.com/tattersoftware/codeigniter4-workflows/actions?query=workflow%3A%22PHPUnit%22)
+[![](https://github.com/tattersoftware/codeigniter4-workflows/workflows/PHPStan/badge.svg)](https://github.com/tattersoftware/codeigniter4-workflows/actions?query=workflow%3A%PHPStan%22)
 
 ## Quick Start
 

--- a/src/Entities/Job.php
+++ b/src/Entities/Job.php
@@ -50,8 +50,11 @@ class Job extends Entity
 	{
 		if (! $this->stageFlag)
 		{
-			$this->stage     = model(StageModel::class)->find($this->attributes['stage_id']);
 			$this->stageFlag = true;
+
+			$this->stage = isset($this->attributes['stage_id'])
+				? model(StageModel::class)->find($this->attributes['stage_id'])
+				: null;
 		}
 
 		return $this->stage;


### PR DESCRIPTION
Fixes an issue where a Job's stageId could be null (correct) causing the model to lookup `find(null)` and return all stages (incorrect).