### PR TITLE
Remove User Role

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ routes that match `/jobs/`, but this can be changed in the config file.
 ## Action permissions
 
 You may limit access to individual Actions using the `role` attribute of its definition.
-By default the "user" `role` is available to everyone. Actions will use the `UserEntity`
+By default an empty `role` is available to everyone. Actions will use the `UserEntity`
 with `HasPermission` interface to test for allowed users.
 
 ## Logging

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,14 @@
+# Upgrade Guide
+
+## Version 3 to 4
+***
+
+* Instead of a session key provide an implementation of `codeigniter4/authentication-implementation` for determining the current user (see [User Guide](https://codeigniter4.github.io/CodeIgniter4/extending/authentication.html)).
+* Corollary, the library assumes the required function is pre-loaded (e.g. call `helper('auth')` before using `Workflows`)
+* Entity stored relations are now private members and will not be available in `$attributes` - extending classes should use the relation getters
+* With `Tatter\Users` the "user role" concept is now obsolete; `role` remains for creating restrictions but unrestricted Actions should use `''` instead of `'user'`
+
+Note: A number of database fields were incorrect (missing defaults, incorrect `null`).
+The migrations [have been updated](https://github.com/tattersoftware/codeigniter4-workflows/commit/5101e8deb005f6da24ab92357b25793616d78252)
+to reflect their proper state. This only really affects testing so new migrations were not
+generated, but current production instances should be aware of the nuanced differences.

--- a/src/Actions/InfoAction.php
+++ b/src/Actions/InfoAction.php
@@ -8,7 +8,7 @@ class InfoAction extends BaseAction
 		'category' => 'Core',
 		'name'     => 'Info',
 		'uid'      => 'info',
-		'role'     => 'user',
+		'role'     => '',
 		'icon'     => 'fas fa-info-circle',
 		'summary'  => 'Set basic details of a job',
 	];

--- a/src/Actions/WorkflowAction.php
+++ b/src/Actions/WorkflowAction.php
@@ -9,7 +9,7 @@ class WorkflowAction extends BaseAction
 		'name'     => 'Workflow',
 		'uid'      => 'workflow',
 		'input'    => 'workflow',
-		'role'     => 'user',
+		'role'     => '',
 		'icon'     => 'fas fa-project-diagram',
 		'summary'  => 'Run another workflow as a subordinate action',
 	];

--- a/src/Entities/Action.php
+++ b/src/Entities/Action.php
@@ -74,7 +74,7 @@ class Action extends Entity
 	public function mayAccess(HasPermission $user = null): bool
 	{
 		// Anyone can run user actions
-		if ($this->attributes['role'] === '' || $this->attributes['role'] === 'user')
+		if ($this->attributes['role'] === '')
 		{
 			return true;
 		}

--- a/src/Entities/Workflow.php
+++ b/src/Entities/Workflow.php
@@ -78,7 +78,7 @@ class Workflow extends Entity
 		}
 
 		// Anyone else is allowed unrestricted Workflows
-		if ($this->attributes['role'] === '' || $this->attributes['role'] === 'user')
+		if ($this->attributes['role'] === '')
 		{
 			return true;
 		}

--- a/src/Models/ActionModel.php
+++ b/src/Models/ActionModel.php
@@ -37,7 +37,7 @@ class ActionModel extends Model
 			'name'        => ucfirst($name),
 			'uid'         => strtolower($name),
 			'class'       => implode('\\', array_map('ucfirst', $faker->words)),
-			'role'        => rand(0, 2) ? 'user' : 'admin',
+			'role'        => rand(0, 2) ? '' : 'admin',
 			'icon'        => $faker->safeColorName,
 			'summary'     => $faker->sentence,
 			'description' => $faker->paragraph,

--- a/tests/entities/WorkflowTest.php
+++ b/tests/entities/WorkflowTest.php
@@ -67,13 +67,6 @@ class WorkflowTest extends DatabaseTestCase
 		$this->assertTrue($this->workflow->mayAccess());
 	}
 
-	public function testMayAccessUser()
-	{
-		$this->workflow->role = 'user';
-
-		$this->assertTrue($this->workflow->mayAccess());
-	}
-
 	public function testMayAccessExplicit()
 	{
 		$explicit = $this->createExplicit();
@@ -129,7 +122,7 @@ class WorkflowTest extends DatabaseTestCase
 		$explicit = $this->createExplicit(['permitted' => 0]);
 		$_SESSION['logged_in'] = $explicit->user_id;
 
-		$this->workflow->role = 'user';
+		$this->workflow->role = '';
 
 		$this->assertFalse($this->workflow->mayAccess());
 	}
@@ -141,7 +134,7 @@ class WorkflowTest extends DatabaseTestCase
 		// Get the UserEntity with HasPermission
 		$user = (new MythFactory)->findById($explicit->user_id);
 
-		$this->workflow->role = 'user';
+		$this->workflow->role = '';
 
 		$this->assertFalse($this->workflow->mayAccess($user));
 	}
@@ -150,7 +143,7 @@ class WorkflowTest extends DatabaseTestCase
 	{
 		$explicit = $this->createExplicit(['permitted' => 0]);
 
-		$this->workflow->role = 'user';
+		$this->workflow->role = '';
 
 		$this->assertFalse($this->workflow->mayAccess(null, [$explicit->id => $explicit->permitted]));
 	}
@@ -162,7 +155,7 @@ class WorkflowTest extends DatabaseTestCase
 		// Get the UserEntity with HasPermission
 		$user = (new MythFactory)->findById($explicit->user_id);
 
-		$this->workflow->role = 'user';
+		$this->workflow->role = '';
 
 		$this->assertFalse($this->workflow->mayAccess($user, [$explicit->id => $explicit->permitted]));
 	}


### PR DESCRIPTION
With `Tatter\Users` the "user role" concept is now obsolete; `role` remains for creating restrictions but unrestricted Actions should use `''` instead of `'user'`. This PR pulls all references to `"user"`