### PR TITLE
Fix class name

### DIFF
--- a/src/Database/Migrations/2021-03-02-091856_create_users_workflows.php
+++ b/src/Database/Migrations/2021-03-02-091856_create_users_workflows.php
@@ -2,7 +2,7 @@
 
 use CodeIgniter\Database\Migration;
 
-class CreateWorkflowsUsers extends Migration
+class CreateUsersWorkflows extends Migration
 {
 	public function up()
 	{


### PR DESCRIPTION
The migration class name does not match its actual file. This does not matter for autoloading but creates confusing in the migration history. Migrations that have already executed may need to be rolled back first.