### PR TITLE
Bugfix resume

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer, pecl, phpunit
-          extensions: intl, json, mbstring, mysqlnd, xdebug, xml, sqlite3
+          extensions: intl, json, mbstring, gd, mysqlnd, xdebug, xml, sqlite3
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           tools: composer, pecl, phpunit
-          extensions: intl, json, mbstring, mysqlnd, xdebug, xml, sqlite3
+          extensions: intl, json, mbstring, gd, mysqlnd, xdebug, xml, sqlite3
           coverage: xdebug
 
       - name: Get composer cache directory
@@ -47,6 +47,9 @@ jobs:
         run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
         env:
           COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
+
+      - name: Enable Tachycardia
+        run: echo "TACHYCARDIA_MONITOR_GA=enabled" >> $GITHUB_ENV
 
       - name: Test with PHPUnit
         run: vendor/bin/phpunit --verbose --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 	"require-dev": {
 		"codeigniter4/codeigniter4": "dev-develop",
 		"myth/auth": "dev-develop",
-		"tatter/tools": "^1.6"
+		"tatter/tools": "^1.7"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,6 +10,7 @@ parameters:
 		- src/Config/Routes.php
 		- src/Views/*
 	ignoreErrors:
+		- '#Call to an undefined method CodeIgniter\\Database\\BaseBuilder::[A-Za-z]+\(\)#'
 		- '#Call to an undefined static method Config\\Services::[A-Za-z]+\(\)#'
 		- '#Cannot access property [\$a-z_]+ on (array|object)#'
 		- '#Unsafe usage of new static\(\)*#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -36,6 +36,27 @@
 		</testsuite>
 	</testsuites>
 
+	<extensions>
+		<extension class="Nexus\PHPUnit\Extension\Tachycardia">
+			<arguments>
+				<array>
+					<element key="timeLimit">
+						<double>0.50</double>
+					</element>
+					<element key="reportable">
+						<integer>30</integer>
+					</element>
+					<element key="precision">
+						<integer>2</integer>
+					</element>
+					<element key="tabulate">
+						<boolean>true</boolean>
+					</element>
+				</array>
+			</arguments>
+		</extension>
+	</extensions>
+
 	<logging>
 		<testdoxHtml outputFile="build/phpunit/testdox.html"/>
 		<testdoxText outputFile="build/phpunit/testdox.txt"/>

--- a/src/Config/Routes.php
+++ b/src/Config/Routes.php
@@ -10,6 +10,7 @@ $routes->get($config->routeBase . '/(:num)/delete',  '\Tatter\Workflows\Controll
 $routes->post($config->routeBase . '/(:num)/delete', '\Tatter\Workflows\Controllers\Jobs::delete/$1');
 
 // Runner route
+$routes->get($config->routeBase . '/(:num)',        '\Tatter\Workflows\Controllers\Runner::resume/$1');
 $routes->post($config->routeBase . '/(:num)',        '\Tatter\Workflows\Controllers\Runner::resume/$1');
 $routes->add($config->routeBase . '/(.+)',           '\Tatter\Workflows\Controllers\Runner::run/$1');
 

--- a/src/Controllers/Runner.php
+++ b/src/Controllers/Runner.php
@@ -51,7 +51,7 @@ class Runner extends Controller
 	 *
 	 * @return ResponseInterface|RedirectResponse  A view to display or a RedirectResponse
 	 */
-	protected function resume($jobId): ResponseInterface
+	public function resume($jobId): ResponseInterface
 	{
 		// Get the Job
 		if ($jobId)

--- a/src/Models/JobModel.php
+++ b/src/Models/JobModel.php
@@ -4,10 +4,11 @@ use CodeIgniter\Model;
 use CodeIgniter\Test\Fabricator;
 use Faker\Generator;
 use Tatter\Workflows\Entities\Job;
+use Tatter\Workflows\Traits\JobsTrait;
 
 class JobModel extends Model
 {
-	use \Tatter\Workflows\Traits\JobsTrait;
+	use JobsTrait;
 
 	protected $table          = 'jobs';
 	protected $returnType     = Job::class;
@@ -41,7 +42,7 @@ class JobModel extends Model
 		// Build the row
 		$row = [
 			'job_id'     => $eventData['id'],
-			'stage_to'   => $eventData['data']['stage_id'],
+			'stage_to'   => $eventData['data']['stage_id'] ?? null,
 			'user_id'    => user_id(),
 			'created_at' => date('Y-m-d H:i:s'),
 		];

--- a/src/Traits/JobsTrait.php
+++ b/src/Traits/JobsTrait.php
@@ -1,8 +1,15 @@
 <?php namespace Tatter\Workflows\Traits;
 
+/**
+ * @mixin \Tatter\Workflows\Model\JobModel
+ */
 trait JobsTrait
 {
-	// Log successful insertions
+	/**
+	 * Logs successful insertions.
+	 *
+	 * @param array $data Event data from trigger
+	 */
 	protected function logInsert(array $data)
 	{
 		if (! $data['result'])
@@ -22,13 +29,16 @@ trait JobsTrait
 		];
 
 		// Add it to the database
-		$db = db_connect();
-		$db->table('joblogs')->insert($row);
+		$this->builder('joblogs')->insert($row);
 
 		return $data;
 	}
 
-	// Log updates that result in a stage change
+	/**
+	 * Logs updates that result in a stage change.
+	 *
+	 * @param array $data Event data from trigger
+	 */
 	protected function logUpdate(array $data)
 	{
 		$db = db_connect();
@@ -68,7 +78,7 @@ trait JobsTrait
 			];
 
 			// Add it to the database
-			$db->table('joblogs')->insert($row);
+			$this->builder('joblogs')->insert($row);
 		}
 
 		return $data;

--- a/tests/_support/DatabaseTestCase.php
+++ b/tests/_support/DatabaseTestCase.php
@@ -1,12 +1,13 @@
 <?php namespace Tests\Support;
 
 use CodeIgniter\Test\CIUnitTestCase;
+use CodeIgniter\Test\DatabaseTestTrait;
 use Tatter\Workflows\Config\Workflows as WorkflowsConfig;
 use Tatter\Workflows\Test\Simulator;
 
 class DatabaseTestCase extends CIUnitTestCase
 {
-	use \CodeIgniter\Test\DatabaseTestTrait;
+	use DatabaseTestTrait;
 
 	/**
 	 * Should the database be refreshed before each test?
@@ -41,7 +42,7 @@ class DatabaseTestCase extends CIUnitTestCase
 	}
 
 	/**
-	 * Makes sure an errors throw exceptions
+	 * Makes sure all errors throw exceptions
 	 */
 	protected function setUp(): void
 	{

--- a/tests/models/JobModelTest.php
+++ b/tests/models/JobModelTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Myth\Auth\Test\Fakers\UserFaker;
+use Tatter\Users\UserEntity;
+use Tatter\Workflows\Entities\Joblog;
+use Tatter\Workflows\Models\JobModel;
+use Tests\Support\DatabaseTestCase;
+
+class JobModelTest extends DatabaseTestCase
+{
+	protected $migrateOnce = true;
+	protected $seedOnce    = true;
+
+	public function testInsertCreatesJoblog()
+	{
+		$jobId = model(JobModel::class)->insert([
+			'name'        => 'Banana Job',
+			'workflow_id' => 1,
+			'stage_id'    => 42,
+		]);
+
+		$this->seeInDatabase('joblogs', [
+			'job_id'     => $jobId,
+			'stage_from' => null,
+			'stage_to'   => 42,
+		]);
+	}
+
+	public function testUpdateCreatesJoblog()
+	{
+		$job = fake(JobModel::class);
+
+		model(JobModel::class)->update($job->id, [
+			'stage_id' => $job->stage_id + 1,
+		]);
+
+		$this->seeInDatabase('joblogs', [
+			'job_id'     => $job->id,
+			'stage_from' => $job->stage_id,
+			'stage_to'   => $job->stage_id + 1,
+		]);
+	}
+}


### PR DESCRIPTION
`Runner::resume()` was accidentally scoped `protected` and listed to POST requests. This PR fixes the scope and includes GET requests for resuming jobs.