### PR TITLE
Enforce coding style

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of Tatter Workflows.
+ *
+ * (c) 2019 Tatter Software
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+use Nexus\CsConfig\Factory;
+use PhpCsFixer\Finder;
+use Utils\PhpCsFixer\CodeIgniter4;
+
+$finder = Finder::create()
+    ->files()
+    ->in(__DIR__)
+    ->append([__FILE__]);
+
+$overrides = [];
+
+$options = [
+    'finder' => $finder,
+];
+
+return Factory::create(new CodeIgniter4(), $overrides, $options)->forLibrary(
+    'Tatter Workflows',
+    'Tatter Software',
+    '',
+    2019
+);

--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,14 @@
         "twbs/bootstrap": "^4.3"
     },
     "require-dev": {
-        "codeigniter4/codeigniter4": "dev-develop",
+        "codeigniter4/codeigniter4": "4.x-dev",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "myth/auth": "dev-develop",
+        "nexusphp/cs-config": "^3.1",
         "tatter/tools": "^1.8"
+    },
+    "config": {
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": {
@@ -47,7 +52,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\Support\\": "tests/_support"
+            "Tests\\Support\\": "tests/_support",
+            "Utils\\": "utils"
         }
     },
     "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -1,75 +1,75 @@
 {
-	"name": "tatter/workflows",
-	"type": "library",
-	"description": "Job task control through dynamic workflows, for CodeIgniter 4",
-	"keywords": [
-		"codeigniter",
-		"codeigniter4",
-		"workflows",
-		"actions",
-		"jobs"
-	],
-	"homepage": "https://github.com/tattersoftware/codeigniter4-workflows",
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "Matthew Gatner",
-			"email": "mgatner@tattersoftware.com",
-			"homepage": "https://tattersoftware.com",
-			"role": "Developer"
-		}
-	],
-	"require": {
-		"php": "^7.3 || ^8.0",
-		"codeigniter4/authentication-implementation": "1.0",
-		"components/jquery": "^3.3",
-		"fortawesome/font-awesome": "^5.8",
-		"npm-asset/sortablejs": "^1.10",
-		"tatter/alerts": "^2.0",
-		"tatter/assets": "^2.0",
-		"tatter/audits": "^1.0",
-		"tatter/handlers": "^2.0",
-		"tatter/users": "^1.0",
-		"twbs/bootstrap": "^4.3"
-	},
-	"require-dev": {
-		"codeigniter4/codeigniter4": "dev-develop",
-		"myth/auth": "dev-develop",
-		"tatter/tools": "^1.8"
-	},
-	"autoload": {
-		"psr-4": {
-			"Tatter\\Workflows\\": "src"
-		},
-		"exclude-from-classmap": [
-			"**/Database/Migrations/**"
-		]
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"Tests\\Support\\": "tests/_support"
-		}
-	},
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "https://github.com/codeigniter4/CodeIgniter4"
-		},
-		{
-			"type": "vcs",
-			"url": "https://github.com/lonnieezell/myth-auth"
-		},
-		{
-			"type": "composer",
-			"url": "https://asset-packagist.org"
-		}
-	],
-	"minimum-stability": "dev",
-	"prefer-stable": true,
-	"scripts": {
-		"analyze": "phpstan analyze",
-		"mutate": "infection --threads=2 --skip-initial-tests --coverage=build/phpunit",
-		"style": "phpcbf --standard=./vendor/codeigniter4/codeigniter4-standard/CodeIgniter4 tests/ src/",
-		"test": "phpunit"
-	}
+    "name": "tatter/workflows",
+    "type": "library",
+    "description": "Job task control through dynamic workflows, for CodeIgniter 4",
+    "keywords": [
+        "codeigniter",
+        "codeigniter4",
+        "workflows",
+        "actions",
+        "jobs"
+    ],
+    "homepage": "https://github.com/tattersoftware/codeigniter4-workflows",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Matthew Gatner",
+            "email": "mgatner@tattersoftware.com",
+            "homepage": "https://tattersoftware.com",
+            "role": "Developer"
+        }
+    ],
+    "require": {
+        "php": "^7.3 || ^8.0",
+        "codeigniter4/authentication-implementation": "1.0",
+        "components/jquery": "^3.3",
+        "fortawesome/font-awesome": "^5.8",
+        "npm-asset/sortablejs": "^1.10",
+        "tatter/alerts": "^2.0",
+        "tatter/assets": "^2.0",
+        "tatter/audits": "^1.0",
+        "tatter/handlers": "^2.0",
+        "tatter/users": "^1.0",
+        "twbs/bootstrap": "^4.3"
+    },
+    "require-dev": {
+        "codeigniter4/codeigniter4": "dev-develop",
+        "myth/auth": "dev-develop",
+        "tatter/tools": "^1.8"
+    },
+    "autoload": {
+        "psr-4": {
+            "Tatter\\Workflows\\": "src"
+        },
+        "exclude-from-classmap": [
+            "**/Database/Migrations/**"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\Support\\": "tests/_support"
+        }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/codeigniter4/CodeIgniter4"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/lonnieezell/myth-auth"
+        },
+        {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "scripts": {
+        "analyze": "phpstan analyze",
+        "mutate": "infection --threads=2 --skip-initial-tests --coverage=build/phpunit",
+        "style": "phpcbf --standard=./vendor/codeigniter4/codeigniter4-standard/CodeIgniter4 tests/ src/",
+        "test": "phpunit"
+    }
 }

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,19 +1,19 @@
 {
-	"source": {
-		"directories": [
-			"src"
-		],
-		"excludes": [
-			"Config",
-			"Database/Migrations",
-			"Views"
-		]
-	},
-	"logs": {
-		"text": "build/infection.log"
-	},
-	"mutators": {
-		"@default": true
-	},
-	"bootstrap": "vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php"
+    "source": {
+        "directories": [
+            "src"
+        ],
+        "excludes": [
+            "Config",
+            "Database/Migrations",
+            "Views"
+        ]
+    },
+    "logs": {
+        "text": "build/infection.log"
+    },
+    "mutators": {
+        "@default": true
+    },
+    "bootstrap": "vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,102 +1,102 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-		bootstrap="vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php"
-		backupGlobals="false"
-		beStrictAboutCoversAnnotation="true"
-		beStrictAboutOutputDuringTests="true"
-		beStrictAboutTodoAnnotatedTests="true"
-		colors="true"
-		convertErrorsToExceptions="true"
-		convertNoticesToExceptions="true"
-		convertWarningsToExceptions="true"
-		executionOrder="random"
-		failOnRisky="true"
-		failOnWarning="true"
-		stopOnError="true"
-		stopOnFailure="false"
-		stopOnIncomplete="false"
-		stopOnSkipped="false"
-		verbose="true">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/codeigniter4/codeigniter4/system/Test/bootstrap.php"
+         backupGlobals="false"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         executionOrder="random"
+         failOnRisky="true"
+         failOnWarning="true"
+         stopOnError="true"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         verbose="true">
 
-	<coverage includeUncoveredFiles="true" processUncoveredFiles="true">
-		<include>
-			<directory suffix=".php">./src</directory>
-		</include>
-		<exclude>
-			<directory suffix=".php">./src/Views</directory>
-			<file>./src/Config/Routes.php</file>
-		</exclude>
-		<report>
-			<clover outputFile="build/phpunit/clover.xml"/>
-			<html outputDirectory="build/phpunit/html"/>
-			<php outputFile="build/phpunit/coverage.serialized"/>
-			<text outputFile="php://stdout" showUncoveredFiles="false"/>
-			<xml outputDirectory="build/phpunit/xml-coverage"/>
-		</report>
-	</coverage>
+    <coverage includeUncoveredFiles="true" processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">./src/Views</directory>
+            <file>./src/Config/Routes.php</file>
+        </exclude>
+        <report>
+            <clover outputFile="build/phpunit/clover.xml"/>
+            <html outputDirectory="build/phpunit/html"/>
+            <php outputFile="build/phpunit/coverage.serialized"/>
+            <text outputFile="php://stdout" showUncoveredFiles="false"/>
+            <xml outputDirectory="build/phpunit/xml-coverage"/>
+        </report>
+    </coverage>
 
-	<testsuites>
-		<testsuite name="app">
-			<directory>./tests</directory>
-		</testsuite>
-	</testsuites>
+    <testsuites>
+        <testsuite name="app">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
 
-	<extensions>
-		<extension class="Nexus\PHPUnit\Extension\Tachycardia">
-			<arguments>
-				<array>
-					<element key="timeLimit">
-						<double>0.50</double>
-					</element>
-					<element key="reportable">
-						<integer>30</integer>
-					</element>
-					<element key="precision">
-						<integer>2</integer>
-					</element>
-					<element key="collectBare">
-						<boolean>true</boolean>
-					</element>
-					<element key="tabulate">
-						<boolean>true</boolean>
-					</element>
-				</array>
-			</arguments>
-		</extension>
-	</extensions>
+    <extensions>
+        <extension class="Nexus\PHPUnit\Extension\Tachycardia">
+            <arguments>
+                <array>
+                    <element key="timeLimit">
+                        <double>0.50</double>
+                    </element>
+                    <element key="reportable">
+                        <integer>30</integer>
+                    </element>
+                    <element key="precision">
+                        <integer>2</integer>
+                    </element>
+                    <element key="collectBare">
+                        <boolean>true</boolean>
+                    </element>
+                    <element key="tabulate">
+                        <boolean>true</boolean>
+                    </element>
+                </array>
+            </arguments>
+        </extension>
+    </extensions>
 
-	<logging>
-		<testdoxHtml outputFile="build/phpunit/testdox.html"/>
-		<testdoxText outputFile="build/phpunit/testdox.txt"/>
-		<junit outputFile="build/phpunit/junit.xml"/>
-	</logging>
+    <logging>
+        <testdoxHtml outputFile="build/phpunit/testdox.html"/>
+        <testdoxText outputFile="build/phpunit/testdox.txt"/>
+        <junit outputFile="build/phpunit/junit.xml"/>
+    </logging>
 
-	<php>
-		<env name="XDEBUG_MODE" value="coverage"/>
-		<server name="app.baseURL" value="http://example.com"/>
+    <php>
+        <env name="XDEBUG_MODE" value="coverage"/>
+        <server name="app.baseURL" value="http://example.com"/>
 
-		<!-- Directory containing phpunit.xml -->
-		<const name="HOMEPATH" value="./"/>
+        <!-- Directory containing phpunit.xml -->
+        <const name="HOMEPATH" value="./"/>
 
-		<!-- Directory containing the Paths config file -->
-		<const name="CONFIGPATH" value="./vendor/codeigniter4/codeigniter4/app/Config/"/>
+        <!-- Directory containing the Paths config file -->
+        <const name="CONFIGPATH" value="./vendor/codeigniter4/codeigniter4/app/Config/"/>
 
-		<!-- Directory containing the front controller (index.php) -->
-		<const name="PUBLICPATH" value="./vendor/codeigniter4/codeigniter4/public/"/>
+        <!-- Directory containing the front controller (index.php) -->
+        <const name="PUBLICPATH" value="./vendor/codeigniter4/codeigniter4/public/"/>
 
-		<!-- https://getcomposer.org/xdebug -->
-		<env name="COMPOSER_DISABLE_XDEBUG_WARN" value="1"/>
+        <!-- https://getcomposer.org/xdebug -->
+        <env name="COMPOSER_DISABLE_XDEBUG_WARN" value="1"/>
 
-		<!-- Database configuration -->
-		<env name="database.tests.strictOn" value="true"/>
-		<!-- Uncomment to use alternate testing database configuration
-		<env name="database.tests.hostname" value="localhost"/>
-		<env name="database.tests.database" value="tests"/>
-		<env name="database.tests.username" value="tests_user"/>
-		<env name="database.tests.password" value=""/>
-		<env name="database.tests.DBDriver" value="MySQLi"/>
-		<env name="database.tests.DBPrefix" value="tests_"/>
-		-->
-	</php>
+        <!-- Database configuration -->
+        <env name="database.tests.strictOn" value="true"/>
+        <!-- Uncomment to use alternate testing database configuration
+        <env name="database.tests.hostname" value="localhost"/>
+        <env name="database.tests.database" value="tests"/>
+        <env name="database.tests.username" value="tests_user"/>
+        <env name="database.tests.password" value=""/>
+        <env name="database.tests.DBDriver" value="MySQLi"/>
+        <env name="database.tests.DBPrefix" value="tests_"/>
+        -->
+    </php>
 </phpunit>

--- a/utils/PhpCsFixer/CodeIgniter4.php
+++ b/utils/PhpCsFixer/CodeIgniter4.php
@@ -1,0 +1,401 @@
+<?php
+
+/**
+ * This file is part of Tatter Workflows.
+ *
+ * (c) 2019 Tatter Software
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Utils\PhpCsFixer;
+
+use Nexus\CsConfig\Ruleset\AbstractRuleset;
+
+/**
+ * @internal
+ */
+final class CodeIgniter4 extends AbstractRuleset
+{
+    public function __construct()
+    {
+        $this->name = 'Tatter Software Coding Standards';
+
+        $this->rules = [
+            'align_multiline_comment' => ['comment_type' => 'all_multiline'],
+            'array_indentation'       => true,
+            'array_push'              => true,
+            'array_syntax'            => ['syntax' => 'short'],
+            'backtick_to_shell_exec'  => true,
+            'binary_operator_spaces'  => [
+                'default'   => 'single_space',
+                'operators' => [
+                    '='  => 'align_single_space_minimal',
+                    '=>' => 'align_single_space_minimal',
+                    '.=' => 'align_single_space_minimal',
+                    '||' => 'align_single_space_minimal',
+                ],
+            ],
+            'blank_line_after_namespace'   => true,
+            'blank_line_after_opening_tag' => true,
+            'blank_line_before_statement'  => [
+                'statements' => [
+                    'break',
+                    'case',
+                    'continue',
+                    'declare',
+                    'default',
+                    'exit',
+                    'goto',
+                    'include',
+                    'include_once',
+                    'require',
+                    'require_once',
+                    'return',
+                    'switch',
+                    'throw',
+                    'try',
+                ],
+            ],
+            'braces' => [
+                'allow_single_line_anonymous_class_with_empty_body' => true,
+                'allow_single_line_closure'                         => true,
+                'position_after_anonymous_constructs'               => 'same',
+                'position_after_control_structures'                 => 'same',
+                'position_after_functions_and_oop_constructs'       => 'next',
+            ],
+            'cast_spaces'                 => ['space' => 'single'],
+            'class_attributes_separation' => [
+                'elements' => [
+                    'const'    => 'one',
+                    'method'   => 'one',
+                    'property' => 'one',
+                ],
+            ],
+            'class_definition' => [
+                'multi_line_extends_each_single_line' => false,
+                'single_item_single_line'             => true,
+                'single_line'                         => true,
+            ],
+            'class_keyword_remove'                 => false,
+            'clean_namespace'                      => true,
+            'combine_consecutive_issets'           => true,
+            'combine_consecutive_unsets'           => true,
+            'combine_nested_dirname'               => true, // risky
+            'comment_to_phpdoc'                    => true, // risky
+            'compact_nullable_typehint'            => true,
+            'concat_space'                         => ['spacing' => 'one'],
+            'constant_case'                        => ['case' => 'lower'],
+            'date_time_immutable'                  => false,
+            'declare_equal_normalize'              => ['space' => 'none'],
+            'declare_strict_types'                 => false,
+            'dir_constant'                         => true, // risky
+            'doctrine_annotation_array_assignment' => false,
+            'doctrine_annotation_braces'           => false,
+            'doctrine_annotation_indentation'      => false,
+            'doctrine_annotation_spaces'           => false,
+            'echo_tag_syntax'                      => [
+                'format'                         => 'short',
+                'long_function'                  => 'echo',
+                'shorten_simple_statements_only' => true,
+            ],
+            'elseif'            => true,
+            'encoding'          => true,
+            'ereg_to_preg'      => true, // risky
+            'error_suppression' => [
+                'mute_deprecation_error'         => true,
+                'noise_remaining_usages'         => false,
+                'noise_remaining_usages_exclude' => [],
+            ], // risky
+            'escape_implicit_backslashes' => [
+                'double_quoted'  => true,
+                'heredoc_syntax' => true,
+                'single_quoted'  => false,
+            ],
+            'explicit_indirect_variable'             => true,
+            'explicit_string_variable'               => true,
+            'final_class'                            => false, // risky
+            'final_internal_class'                   => true, // risky
+            'final_public_method_for_abstract_class' => false, // risky
+            'fopen_flag_order'                       => true, // risky
+            'fopen_flags'                            => ['b_mode' => true], // risky
+            'full_opening_tag'                       => true,
+            'fully_qualified_strict_types'           => true,
+            'function_declaration'                   => ['closure_function_spacing' => 'one'],
+            'function_to_constant'                   => [
+                'functions' => [ // risky
+                    'get_called_class',
+                    'get_class',
+                    'get_class_this',
+                    'php_sapi_name',
+                    'phpversion',
+                    'pi',
+                ],
+            ],
+            'function_typehint_space'          => true,
+            'general_phpdoc_annotation_remove' => [
+                'annotations' => [
+                    'author',
+                    'package',
+                    'subpackage',
+                ],
+            ],
+            'general_phpdoc_tag_rename' => [
+                'case_sensitive' => false,
+                'fix_annotation' => true,
+                'fix_inline'     => true,
+                'replacements'   => ['inheritDocs' => 'inheritDoc'],
+            ],
+            'global_namespace_import'     => ['import_classes' => true],
+            'group_import'                => false,
+            'header_comment'              => false,
+            'heredoc_indentation'         => false,
+            'heredoc_to_nowdoc'           => true,
+            'implode_call'                => true, // risky
+            'include'                     => true,
+            'increment_style'             => ['style' => 'post'],
+            'indentation_type'            => true,
+            'is_null'                     => true, // risky
+            'lambda_not_used_import'      => true,
+            'line_ending'                 => true,
+            'linebreak_after_opening_tag' => true,
+            'list_syntax'                 => ['syntax' => 'short'],
+            'logical_operators'           => true, // risky
+            'lowercase_cast'              => true,
+            'lowercase_keywords'          => true,
+            'lowercase_static_reference'  => true,
+            'magic_constant_casing'       => true,
+            'magic_method_casing'         => true,
+            'mb_str_functions'            => false, // risky
+            'method_argument_space'       => [
+                'after_heredoc'                    => true,
+                'keep_multiple_spaces_after_comma' => false,
+                'on_multiline'                     => 'ensure_fully_multiline',
+            ],
+            'method_chaining_indentation'             => true,
+            'modernize_types_casting'                 => true, // risky
+            'multiline_comment_opening_closing'       => true,
+            'multiline_whitespace_before_semicolons'  => ['strategy' => 'no_multi_line'],
+            'native_constant_invocation'              => false, // risky
+            'native_function_casing'                  => true,
+            'native_function_invocation'              => false, // risky
+            'native_function_type_declaration_casing' => true,
+            'new_with_braces'                         => true,
+            'no_alias_functions'                      => true, // risky
+            'no_alias_language_construct_call'        => true,
+            'no_alternative_syntax'                   => false,
+            'no_binary_string'                        => true,
+            'no_blank_lines_after_class_opening'      => true,
+            'no_blank_lines_after_phpdoc'             => true,
+            'no_blank_lines_before_namespace'         => false,
+            'no_break_comment'                        => true,
+            'no_closing_tag'                          => true,
+            'no_empty_comment'                        => true,
+            'no_empty_phpdoc'                         => true,
+            'no_empty_statement'                      => true,
+            'no_extra_blank_lines'                    => [
+                'tokens' => [
+                    'extra',
+                    'break',
+                    'continue',
+                    'curly_brace_block',
+                    'parenthesis_brace_block',
+                    'square_brace_block',
+                    'return',
+                    'throw',
+                    'use',
+                    'use_trait',
+                    'switch',
+                    'case',
+                    'default',
+                ],
+            ],
+            'no_homoglyph_names'                          => true, // risky
+            'no_leading_import_slash'                     => true,
+            'no_leading_namespace_whitespace'             => true,
+            'no_mixed_echo_print'                         => ['use' => 'echo'],
+            'no_multiline_whitespace_around_double_arrow' => true,
+            'no_null_property_initialization'             => true,
+            'no_php4_constructor'                         => true, // risky
+            'no_short_bool_cast'                          => true,
+            'no_singleline_whitespace_before_semicolons'  => true,
+            'no_spaces_after_function_name'               => true,
+            'no_spaces_around_offset'                     => [
+                'positions' => [
+                    'inside',
+                    'outside',
+                ],
+            ],
+            'no_spaces_inside_parenthesis'                     => true,
+            'no_superfluous_elseif'                            => true,
+            'no_superfluous_phpdoc_tags'                       => false,
+            'no_trailing_comma_in_list_call'                   => true,
+            'no_trailing_comma_in_singleline_array'            => true,
+            'no_trailing_whitespace'                           => true,
+            'no_trailing_whitespace_in_comment'                => true,
+            'no_trailing_whitespace_in_string'                 => true, // risky
+            'no_unneeded_control_parentheses'                  => true,
+            'no_unneeded_curly_braces'                         => ['namespaces' => true],
+            'no_unneeded_final_method'                         => true, // risky
+            'no_unreachable_default_argument_value'            => true, // risky
+            'no_unset_cast'                                    => true,
+            'no_unset_on_property'                             => false, // risky
+            'no_unused_imports'                                => true,
+            'no_useless_else'                                  => true,
+            'no_useless_return'                                => true,
+            'no_useless_sprintf'                               => true, // risky
+            'no_whitespace_before_comma_in_array'              => true,
+            'no_whitespace_in_blank_line'                      => true,
+            'non_printable_character'                          => true, // risky
+            'normalize_index_brace'                            => true,
+            'not_operator_with_space'                          => false,
+            'not_operator_with_successor_space'                => true,
+            'nullable_type_declaration_for_default_null_value' => ['use_nullable_type_declaration' => false],
+            'object_operator_without_whitespace'               => true,
+            'operator_linebreak'                               => [
+                'only_booleans' => false,
+                'position'      => 'beginning',
+            ],
+            'ordered_class_elements' => [
+                'order' => [
+                    'use_trait',
+                    'constant_public',
+                    'constant_protected',
+                    'constant_private',
+                    'property_public',
+                    'property_protected',
+                    'property_private',
+                    'construct',
+                    'destruct',
+                    'magic',
+                    'phpunit',
+                    'method_public_static',
+                    'method_protected_static',
+                    'method_private_static',
+                    'method_public',
+                    'method_protected',
+                    'method_private',
+                ],
+            ],
+            'ordered_imports'                        => true,
+            'ordered_interfaces'                     => false, // risky
+            'ordered_traits'                         => true,
+            'php_unit_construct'                     => true, // risky
+            'php_unit_dedicate_assert'               => ['target' => 'newest'], // risky
+            'php_unit_dedicate_assert_internal_type' => ['target' => 'newest'], // risky
+            'php_unit_expectation'                   => true, // risky
+            'php_unit_fqcn_annotation'               => true,
+            'php_unit_internal_class'                => true,
+            'php_unit_method_casing'                 => true,
+            'php_unit_mock'                          => true, // risky
+            'php_unit_mock_short_will_return'        => true, // risky
+            'php_unit_namespaced'                    => true, // risky
+            'php_unit_no_expectation_annotation'     => true, // risky
+            'php_unit_set_up_tear_down_visibility'   => true, // risky
+            'php_unit_size_class'                    => false,
+            'php_unit_strict'                        => true, // risky
+            'php_unit_test_annotation'               => false, // risky
+            'php_unit_test_case_static_method_calls' => ['call_type' => 'self'], // risky
+            'php_unit_test_class_requires_covers'    => false,
+            'phpdoc_add_missing_param_annotation'    => ['only_untyped' => false],
+            'phpdoc_align'                           => true,
+            'phpdoc_annotation_without_dot'          => true,
+            'phpdoc_indent'                          => true,
+            'phpdoc_inline_tag_normalizer'           => true,
+            'phpdoc_line_span'                       => [
+                'const'    => 'multi',
+                'method'   => 'multi',
+                'property' => 'multi',
+            ],
+            'phpdoc_no_access'               => true,
+            'phpdoc_no_alias_tag'            => true,
+            'phpdoc_no_empty_return'         => false,
+            'phpdoc_no_package'              => true,
+            'phpdoc_no_useless_inheritdoc'   => true,
+            'phpdoc_order'                   => true,
+            'phpdoc_order_by_value'          => true,
+            'phpdoc_return_self_reference'   => true,
+            'phpdoc_scalar'                  => true,
+            'phpdoc_separation'              => true,
+            'phpdoc_single_line_var_spacing' => true,
+            'phpdoc_summary'                 => true,
+            'phpdoc_tag_casing'              => true,
+            'phpdoc_tag_type'                => [
+                'tags' => ['inheritDoc' => 'inline'],
+            ],
+            'phpdoc_to_comment'                             => true,
+            'phpdoc_to_param_type'                          => false, // risky
+            'phpdoc_to_property_type'                       => false, // risky, for PHP 7.4+
+            'phpdoc_to_return_type'                         => false, // risky
+            'phpdoc_trim'                                   => true,
+            'phpdoc_trim_consecutive_blank_line_separation' => true,
+            'phpdoc_types'                                  => true,
+            'phpdoc_types_order'                            => [
+                'null_adjustment' => 'always_last',
+                'sort_algorithm'  => 'alpha',
+            ],
+            'phpdoc_var_annotation_correct_order' => true,
+            'phpdoc_var_without_name'             => true,
+            'pow_to_exponentiation'               => true,
+            'protected_to_private'                => true,
+            'psr_autoloading'                     => ['dir' => null],
+            'random_api_migration'                => true,
+            'regular_callable_call'               => true, // risky
+            'return_assignment'                   => true,
+            'return_type_declaration'             => true,
+            'self_accessor'                       => true, // risky
+            'self_static_accessor'                => true,
+            'semicolon_after_instruction'         => true,
+            'set_type_to_cast'                    => true, // risky
+            'short_scalar_cast'                   => true,
+            'simple_to_complex_string_variable'   => true,
+            'simplified_if_return'                => true,
+            'simplified_null_return'              => false,
+            'single_blank_line_at_eof'            => true,
+            'single_blank_line_before_namespace'  => true,
+            'single_class_element_per_statement'  => true,
+            'single_import_per_statement'         => true,
+            'single_line_after_imports'           => true,
+            'single_line_comment_style'           => true,
+            'single_line_throw'                   => false,
+            'single_quote'                        => true,
+            'single_space_after_construct'        => true,
+            'single_trait_insert_per_statement'   => true,
+            'space_after_semicolon'               => true,
+            'standardize_increment'               => true,
+            'standardize_not_equals'              => true,
+            'static_lambda'                       => true, // risky
+            'strict_comparison'                   => true, // risky
+            'strict_param'                        => true, // risky
+            'string_line_ending'                  => true, // risky
+            'switch_case_semicolon_to_colon'      => true,
+            'switch_case_space'                   => true,
+            'switch_continue_to_break'            => true,
+            'ternary_operator_spaces'             => true,
+            'ternary_to_elvis_operator'           => true, // risky
+            'ternary_to_null_coalescing'          => true,
+            'trailing_comma_in_multiline'         => [
+                'after_heredoc' => false,
+                'elements'      => ['arrays'],
+            ],
+            'trim_array_spaces'     => true,
+            'unary_operator_spaces' => true,
+            'use_arrow_functions'   => false, // risky
+            'visibility_required'   => [
+                'elements' => [
+                    'const',
+                    'method',
+                    'property',
+                ],
+            ],
+            'void_return'                     => false, // risky
+            'whitespace_after_comma_in_array' => true,
+            'yoda_style'                      => false,
+        ];
+
+        $this->requiredPHPVersion = 70300;
+
+        $this->autoActivateIsRiskyAllowed = true;
+    }
+}


### PR DESCRIPTION
This PR creates a coding style ruleset for the `tattersoftware` org. I cannot link this to the in-development version in `codeigniter4/codeigniter4` because of autoloading issues. So, this copies the one in the `translations` repo and adjusted some rules to conform with PSR12.

I have not yet applied the rules into the codebase so you can tinker around the rules and check the effects. Description for the rules can be checked here: https://mlocati.github.io/php-cs-fixer-configurator/#version:3.0